### PR TITLE
FIX: webpack error: 'import not found'

### DIFF
--- a/frontend/src/components/index.js
+++ b/frontend/src/components/index.js
@@ -3,6 +3,4 @@ import News from "./News";
 
 export default NavBar;
 
-export {
-  News
-};
+export { News };


### PR DESCRIPTION
- for some reason react webpack was saying that my import was not found.